### PR TITLE
feat: multi-layer support, year slider dots, zoom button, ui polish

### DIFF
--- a/e-safari-ui/package-lock.json
+++ b/e-safari-ui/package-lock.json
@@ -2510,7 +2510,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2519,7 +2518,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }

--- a/e-safari-ui/src/Portal.tsx
+++ b/e-safari-ui/src/Portal.tsx
@@ -333,6 +333,7 @@ const Portal = ({ language }: PortalProps) => {
             <button
               type="button"
               title={language === 'fr' ? 'Zoom sur la couche' : 'Zoom to layer'}
+              aria-label={language === 'fr' ? 'Zoom sur la couche' : 'Zoom to layer'}
               onClick={handleZoomToLayers}
               style={{
                 position: 'absolute',

--- a/e-safari-ui/src/Portal.tsx
+++ b/e-safari-ui/src/Portal.tsx
@@ -209,6 +209,8 @@ const Portal = ({ language }: PortalProps) => {
     const map = mapRef?.current as any;
     if (!map) return;
 
+    let cancelled = false;
+
     const applyRasterLayers = () => {
       // Remove rasters whose layers are no longer active
       Object.entries(loadedRasterIdsRef.current).forEach(([layerId, rasterId]) => {
@@ -232,6 +234,12 @@ const Portal = ({ language }: PortalProps) => {
 
         fetchDatasetVisualization({ datasetId: layer.dataset.id, cadence, date: vizDate })
           .then((payload) => {
+            // Discard stale responses: layer may have been toggled off or the
+            // selection/date may have changed since this request was issued.
+            if (cancelled) return;
+            if (!activeLayerIds.includes(layer.id)) return;
+            const currentSelection = layerSelections[layer.id] || {};
+            if (buildVisualizationDate(cadence, currentSelection) !== vizDate) return;
             if (!payload.tileUrl) return;
             // Remove stale tile for this layer before adding the refreshed one
             if (map.getSource(rasterId)) remove_image_layer(map, rasterId);
@@ -251,7 +259,7 @@ const Portal = ({ language }: PortalProps) => {
             }
           })
           .catch(() => {
-            remove_image_layer(map, rasterId);
+            if (!cancelled) remove_image_layer(map, rasterId);
           });
       });
     };
@@ -261,6 +269,10 @@ const Portal = ({ language }: PortalProps) => {
     } else {
       map.once('load', applyRasterLayers);
     }
+
+    return () => {
+      cancelled = true;
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeLayerIds, activeLayers, layerSelections, mapRef]);
 

--- a/e-safari-ui/src/Portal.tsx
+++ b/e-safari-ui/src/Portal.tsx
@@ -268,6 +268,9 @@ const Portal = ({ language }: PortalProps) => {
       applyRasterLayers();
     } else {
       map.once('load', applyRasterLayers);
+      return () => {
+        map.off('load', applyRasterLayers);
+      };
     }
 
     return () => {

--- a/e-safari-ui/src/Portal.tsx
+++ b/e-safari-ui/src/Portal.tsx
@@ -7,7 +7,7 @@ import { GeocodingControl } from '@maptiler/geocoding-control/react';
 import { createMapLibreGlMapController } from '@maptiler/geocoding-control/maplibregl-controller';
 import maplibregl from 'maplibre-gl';
 import '@maptiler/geocoding-control/style.css';
-import { Menu } from 'lucide-react';
+import { Locate, Menu } from 'lucide-react';
 import { Button } from './components/ui/button';
 import { Language } from './types';
 import RightBar from './components/RightBar';
@@ -24,6 +24,7 @@ import {
   fetchDatasetVisualization,
   getFallbackSelectorOptions,
 } from './services/layersApi';
+import type { BoundsObject } from './services/layersApi';
 import type { LayerSelectOption, LayerSelectionValue, SelectorKey } from './types/catalogLayer';
 import { addLegendOnce, renderLegend } from './components/LegendUtils';
 import { useLegendStore } from './components/stores/useLegendStore';
@@ -44,7 +45,7 @@ const Portal = ({ language }: PortalProps) => {
   const [rightBarTab, setRightBarTab] = useState<'Legend' | 'Analysis'>('Legend');
   const [showMobilePanel, setShowMobilePanel] = useState(false);
   const [selectedFeature] = useState<SelectedFeature | null>(null);
-  const [opacity, setOpacity] = useState<number>(85);
+  const [opacities, setOpacities] = useState<Record<string, number>>({});
   const [mapController, setMapController] = useState<ReturnType<typeof createMapLibreGlMapController>>();
   const [countries, setCountries] = useState<CountryOption[]>([]);
   const [selectedCountry, setSelectedCountry] = useState<CountryOption | null>(null);
@@ -54,26 +55,23 @@ const Portal = ({ language }: PortalProps) => {
   const [availabilityCache, setAvailabilityCache] = useState<
     Record<string, { available: string[]; max: string }>
   >({});
-  const loadedRasterIdRef = useRef<string | null>(null);
+  const loadedRasterIdsRef = useRef<Record<string, string>>({});
+  // Flips true after the very first auto-zoom; never resets so only one auto-zoom ever occurs
+  const hasInitialZoomedRef = useRef<boolean>(false);
+  const [layerBounds, setLayerBounds] = useState<Record<string, BoundsObject | null>>({});
 
   const {
     layers,
     loading,
     error,
-    activeLayerId,
-    activeLayer,
-    setActiveLayerId,
+    activeLayerIds,
+    activeLayers,
+    toggleActiveLayer,
     layerSelections,
     setLayerSelections,
   } = useCatalogLayers(language);
 
   const { mapRef } = useMap() ?? { mapRef: { current: null } };
-
-  useEffect(() => {
-    if (activeLayer) {
-      setOpacity(activeLayer.ui?.opacity ?? 85);
-    }
-  }, [activeLayer?.id]);
 
   useEffect(() => {
     fetch('/api/catalog/projects/e-safari/countries/')
@@ -91,11 +89,11 @@ const Portal = ({ language }: PortalProps) => {
     map.fitBounds([[west, south], [east, north]], { padding: 40 });
   };
 
-  const handleOpacityChange = (value: number) => {
-    setOpacity(value);
+  const handleOpacityChange = (layerId: string, value: number) => {
+    setOpacities((prev) => ({ ...prev, [layerId]: value }));
     const map = mapRef?.current;
-    const rasterId = loadedRasterIdRef.current;
-    if (map && rasterId && map.getLayer(rasterId)) {
+    const rasterId = `raster-${layerId}`;
+    if (map && map.getLayer(rasterId)) {
       map.setPaintProperty(rasterId, 'raster-opacity', value / 100);
     }
   };
@@ -124,92 +122,60 @@ const Portal = ({ language }: PortalProps) => {
     });
   };
 
-  // Effect 1: Fetch availability when dataset/cadence changes
+  // Effect 1: Fetch availability for each active layer not yet cached
   useEffect(() => {
-    if (!activeLayer || activeLayer.type !== 'raster') {
-      return;
-    }
+    activeLayers.forEach((layer) => {
+      if (layer.type !== 'raster') return;
+      const cadence = layer.dataset.cadence;
+      const datasetId = layer.dataset.id;
+      const cacheKey = `${datasetId}-${cadence}`;
+      if (availabilityCache[cacheKey]) return;
 
-    const cadence = activeLayer.dataset.cadence;
-    const datasetId = activeLayer.dataset.id;
-    const cacheKey = `${datasetId}-${cadence}`;
-
-    // Skip if already cached
-    if (availabilityCache[cacheKey]) {
-      return;
-    }
-
-    fetchDatasetAvailability({ datasetId, cadence })
-      .then((availability) => {
-        const available = availability.options.map((option) => option.value);
-        setAvailabilityCache((previous) => ({
-          ...previous,
-          [cacheKey]: { available, max: availability.max },
-        }));
-
-        // Set default selection if none exists
-        const defaultSelection = defaultSelectionFromAvailability(
-          cadence,
-          available,
-          availability.max,
-        );
-
-        setLayerSelections((previous) => {
-          const current = previous[activeLayer.id] || {};
-          if (buildVisualizationDate(cadence, current)) {
-            return previous;
-          }
-          return {
+      fetchDatasetAvailability({ datasetId, cadence })
+        .then((availability) => {
+          const available = availability.options.map((option) => option.value);
+          setAvailabilityCache((previous) => ({
             ...previous,
-            [activeLayer.id]: { ...current, ...defaultSelection },
-          };
+            [cacheKey]: { available, max: availability.max ?? '' },
+          }));
+          const defaultSelection = defaultSelectionFromAvailability(cadence, available, availability.max);
+          setLayerSelections((previous) => {
+            const current = previous[layer.id] || {};
+            if (buildVisualizationDate(cadence, current)) return previous;
+            return { ...previous, [layer.id]: { ...current, ...defaultSelection } };
+          });
+        })
+        .catch(() => {
+          setAvailabilityCache((previous) => ({
+            ...previous,
+            [cacheKey]: { available: [], max: '' },
+          }));
         });
-      })
-      .catch(() => {
-        // On error, set empty cache to allow retry
-        setAvailabilityCache((previous) => ({
-          ...previous,
-          [cacheKey]: { available: [], max: '' },
-        }));
-      });
-  }, [activeLayer?.id, activeLayer?.dataset.id, activeLayer?.dataset.cadence, setLayerSelections]);
-
-  // Effect 2: Recompute options whenever active layer selection changes
-  useEffect(() => {
-    if (!activeLayer || activeLayer.type !== 'raster') {
-      return;
-    }
-
-    const cadence = activeLayer.dataset.cadence;
-    const datasetId = activeLayer.dataset.id;
-    const cacheKey = `${datasetId}-${cadence}`;
-    const cached = availabilityCache[cacheKey];
-
-    if (!cached) {
-      return;
-    }
-
-    const currentSelection = layerSelections[activeLayer.id] || {};
-    const nextOptions: Partial<Record<SelectorKey, LayerSelectOption[]>> = {};
-
-    activeLayer.selectors.forEach((selector) => {
-      const fromApi = optionsFromAvailability(
-        cached.available,
-        selector.key,
-        currentSelection,
-        language,
-      );
-      nextOptions[selector.key] =
-        fromApi.length > 0
-          ? fromApi
-          : getFallbackSelectorOptions(selector.key, language);
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeLayerIds, layers, availabilityCache]);
 
-    setLayerSelectionOptions((previous) => ({
-      ...previous,
-      [activeLayer.id]: nextOptions,
-    }));
-  }, [activeLayer?.id, activeLayer?.dataset.id, activeLayer?.dataset.cadence, activeLayer?.selectors, layerSelections, availabilityCache, language]);
+  // Effect 2: Recompute selector options for all active layers
+  useEffect(() => {
+    activeLayers.forEach((layer) => {
+      if (layer.type !== 'raster') return;
+      const cacheKey = `${layer.dataset.id}-${layer.dataset.cadence}`;
+      const cached = availabilityCache[cacheKey];
+      if (!cached) return;
+
+      const currentSelection = layerSelections[layer.id] || {};
+      const nextOptions: Partial<Record<SelectorKey, LayerSelectOption[]>> = {};
+
+      layer.selectors.forEach((selector) => {
+        const fromApi = optionsFromAvailability(cached.available, selector.key, currentSelection, language);
+        nextOptions[selector.key] =
+          fromApi.length > 0 ? fromApi : getFallbackSelectorOptions(selector.key, language);
+      });
+
+      setLayerSelectionOptions((previous) => ({ ...previous, [layer.id]: nextOptions }));
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeLayerIds, layers, availabilityCache, layerSelections, language]);
 
   useEffect(() => {
     let cancelled = false;
@@ -239,65 +205,77 @@ const Portal = ({ language }: PortalProps) => {
   }, [mapRef]);
 
   useEffect(() => {
-    const map = mapRef?.current;
-    if (!map) {
-      return;
-    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = mapRef?.current as any;
+    if (!map) return;
 
-    const applyRasterLayer = () => {
-      const previousRasterId = loadedRasterIdRef.current;
-      if (previousRasterId) {
-        remove_image_layer(map, previousRasterId);
-        loadedRasterIdRef.current = null;
-      }
+    const applyRasterLayers = () => {
+      // Remove rasters whose layers are no longer active
+      Object.entries(loadedRasterIdsRef.current).forEach(([layerId, rasterId]) => {
+        if (!activeLayerIds.includes(layerId)) {
+          remove_image_layer(map, rasterId);
+          delete loadedRasterIdsRef.current[layerId];
+          const title = layers.find((l) => l.id === layerId)?.title;
+          if (title) useLegendStore.getState().removeLegendByTitle(title);
+        }
+      });
 
-      if (!activeLayer || activeLayer.type !== 'raster') {
-        useLegendStore.getState().clearLegends();
-        return;
-      }
+      // Add/refresh each active raster layer
+      activeLayers.forEach((layer) => {
+        if (layer.type !== 'raster') return;
+        const cadence = layer.dataset.cadence;
+        const selection = layerSelections[layer.id] || {};
+        const vizDate = buildVisualizationDate(cadence, selection);
+        if (!vizDate) return;
 
-      const cadence = activeLayer.dataset.cadence;
-      const selection = layerSelections[activeLayer.id] || {};
-      const vizDate = buildVisualizationDate(cadence, selection);
-      if (!vizDate) {
-        return;
-      }
+        const rasterId = `raster-${layer.id}`;
 
-      const rasterLayerId = `raster-${activeLayer.id}`;
-
-      fetchDatasetVisualization({
-        datasetId: activeLayer.dataset.id,
-        cadence,
-        date: vizDate,
-      })
-        .then((payload) => {
-          if (loadedRasterIdRef.current && loadedRasterIdRef.current !== rasterLayerId) {
-            remove_image_layer(map, loadedRasterIdRef.current);
-          }
-          if (!payload.tileUrl) {
-            return;
-          }
-          add_image_layer(map, payload.tileUrl, rasterLayerId, true, payload.bounds, true, opacity / 100);
-          loadedRasterIdRef.current = rasterLayerId;
-
-          useLegendStore.getState().clearLegends();
-          const legendMap = activeLayer.legend;
-          if (legendMap && Object.keys(legendMap).length > 0) {
-            const legendNode = renderLegend(legendMap, activeLayer.title);
-            addLegendOnce(legendNode, activeLayer.title);
-          }
-        })
-        .catch(() => {
-          remove_image_layer(map, rasterLayerId);
-        });
+        fetchDatasetVisualization({ datasetId: layer.dataset.id, cadence, date: vizDate })
+          .then((payload) => {
+            if (!payload.tileUrl) return;
+            // Remove stale tile for this layer before adding the refreshed one
+            if (map.getSource(rasterId)) remove_image_layer(map, rasterId);
+            add_image_layer(map, payload.tileUrl, rasterId, true, payload.bounds, false, (opacities[layer.id] ?? layer.ui?.opacity ?? 85) / 100);
+            loadedRasterIdsRef.current[layer.id] = rasterId;
+            // Store bounds for the zoom button
+            setLayerBounds((prev) => ({ ...prev, [layer.id]: payload.bounds }));
+            // Auto-zoom once ever on first layer load
+            if (!hasInitialZoomedRef.current && payload.bounds) {
+              const { minx, miny, maxx, maxy } = payload.bounds;
+              map.fitBounds([[minx, miny], [maxx, maxy]], { padding: 40 });
+              hasInitialZoomedRef.current = true;
+            }
+            const legendMap = layer.legend;
+            if (legendMap && Object.keys(legendMap).length > 0) {
+              addLegendOnce(renderLegend(legendMap, layer.title), layer.title);
+            }
+          })
+          .catch(() => {
+            remove_image_layer(map, rasterId);
+          });
+      });
     };
 
     if (map.isStyleLoaded()) {
-      applyRasterLayer();
+      applyRasterLayers();
     } else {
-      map.once('load', applyRasterLayer);
+      map.once('load', applyRasterLayers);
     }
-  }, [activeLayer, layerSelections, mapRef]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeLayerIds, activeLayers, layerSelections, mapRef]);
+
+  const handleZoomToLayers = () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = mapRef?.current as any;
+    if (!map || activeLayerIds.length === 0) return;
+    const bounds = activeLayerIds.map((id) => layerBounds[id]).filter(Boolean) as BoundsObject[];
+    if (bounds.length === 0) return;
+    const minx = Math.min(...bounds.map((b) => b.minx));
+    const miny = Math.min(...bounds.map((b) => b.miny));
+    const maxx = Math.max(...bounds.map((b) => b.maxx));
+    const maxy = Math.max(...bounds.map((b) => b.maxy));
+    map.fitBounds([[minx, miny], [maxx, maxy]], { padding: 40 });
+  };
 
   return (
     <div className="h-full min-h-0 overflow-hidden flex flex-col bg-gray-50">
@@ -329,19 +307,21 @@ const Portal = ({ language }: PortalProps) => {
           <div className="flex-1 overflow-y-auto">
             <LayerControls
               layers={layers}
-              activeLayerId={activeLayerId}
-              onLayerChange={(layerId) => {
-                setActiveLayerId(layerId);
+              activeLayerIds={activeLayerIds}
+              onLayerToggle={(layerId: string) => {
+                toggleActiveLayer(layerId);
                 setRightBarTab('Legend');
+                // Seed opacity from layer config if not yet set
+                const layer = layers.find((l) => l.id === layerId);
+                if (layer) setOpacities((prev) => ({ [layerId]: layer.ui?.opacity ?? 85, ...prev }));
               }}
-              onLayerDeactivate={() => setActiveLayerId(null)}
               language={language}
               selectionValues={layerSelections}
               selectionOptions={layerSelectionOptions}
               onSelectionChange={handleSelectionChange}
               loading={loading}
               error={error}
-              opacity={opacity}
+              opacities={opacities}
               onOpacityChange={handleOpacityChange}
             />
           </div>
@@ -349,8 +329,33 @@ const Portal = ({ language }: PortalProps) => {
 
         <div className="flex-1 min-h-0 relative">
           <Map />
+          {activeLayerIds.length > 0 && (
+            <button
+              type="button"
+              title={language === 'fr' ? 'Zoom sur la couche' : 'Zoom to layer'}
+              onClick={handleZoomToLayers}
+              style={{
+                position: 'absolute',
+                top: 115,
+                right: 20,
+                zIndex: 1000,
+                width: 29,
+                height: 29,
+                backgroundColor: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                boxShadow: '0 0 0 2px rgba(0,0,0,.1)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Locate style={{ width: 15, height: 15, color: '#374151' }} />
+            </button>
+          )}
           <RightBar
-            activeLayer={activeLayer}
+            activeLayer={activeLayers[0] ?? null}
             language={language}
             selectedFeature={selectedFeature}
             activeTab={rightBarTab}
@@ -371,20 +376,21 @@ const Portal = ({ language }: PortalProps) => {
           isOpen={showMobilePanel}
           onClose={() => setShowMobilePanel(false)}
           layers={layers}
-          activeLayerId={activeLayerId}
-          onLayerChange={(layerId) => {
-            setActiveLayerId(layerId);
+          activeLayerIds={activeLayerIds}
+          onLayerToggle={(layerId: string) => {
+            toggleActiveLayer(layerId);
             setRightBarTab('Legend');
+            const layer = layers.find((l) => l.id === layerId);
+            if (layer) setOpacities((prev) => ({ [layerId]: layer.ui?.opacity ?? 85, ...prev }));
           }}
-          onLayerDeactivate={() => setActiveLayerId(null)}
           language={language}
           selectionValues={layerSelections}
           selectionOptions={layerSelectionOptions}
           onSelectionChange={handleSelectionChange}
           loading={loading}
           error={error}
-          activeLayer={activeLayer}
-          opacity={opacity}
+          activeLayer={activeLayers[0] ?? null}
+          opacities={opacities}
           onOpacityChange={handleOpacityChange}
         />
       </div>

--- a/e-safari-ui/src/components/LayerControls.tsx
+++ b/e-safari-ui/src/components/LayerControls.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Select from 'react-select';
 import { ChevronRight, Info, Layers } from 'lucide-react';
 import { Language } from '../types';
@@ -14,17 +14,16 @@ import '../styles/layercontrol.css';
 
 interface LayerControlsProps {
   layers: CatalogLayer[];
-  activeLayerId: string | null;
-  onLayerChange: (layerId: string) => void;
-  onLayerDeactivate: () => void;
+  activeLayerIds: string[];
+  onLayerToggle: (layerId: string) => void;
   language: Language;
   selectionValues: Record<string, LayerSelectionValue>;
   selectionOptions: Record<string, Partial<Record<SelectorKey, LayerSelectOption[]>>>;
   onSelectionChange: (layerId: string, field: SelectorKey, value?: string) => void;
   loading?: boolean;
   error?: string | null;
-  opacity: number;
-  onOpacityChange: (value: number) => void;
+  opacities: Record<string, number>;
+  onOpacityChange: (layerId: string, value: number) => void;
 }
 
 const translations = {
@@ -69,20 +68,36 @@ function MetaRow({ label, value }: { label: string; value: string }) {
 
 export function LayerControls({
   layers,
-  activeLayerId,
-  onLayerChange,
-  onLayerDeactivate,
+  activeLayerIds,
+  onLayerToggle,
   language,
   selectionValues,
   selectionOptions,
   onSelectionChange,
   loading,
   error,
-  opacity,
+  opacities,
   onOpacityChange,
 }: LayerControlsProps) {
   const t = translations[language];
   const [infoLayerId, setInfoLayerId] = useState<string | null>(null);
+
+  // Auto-select the first available option for any selector that has no current value.
+  // Fires when options load OR when the active layer set changes.
+  useEffect(() => {
+    layers.forEach((layer) => {
+      layer.selectors.forEach((field) => {
+        const options = selectionOptions[layer.id]?.[field.key];
+        if (!options?.length) return;
+        const current = selectionValues[layer.id]?.[field.key];
+        if (!current) {
+          onSelectionChange(layer.id, field.key, options[0].value);
+        }
+      });
+    });
+  // selectionValues intentionally omitted — the !current guard prevents loops
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectionOptions, activeLayerIds, layers]);
 
   const isFieldEnabled = (selection: LayerSelectionValue, field: SelectorConfig) => {
     if (!field.dependsOn || field.dependsOn.length === 0) return true;
@@ -105,7 +120,7 @@ export function LayerControls({
       {titleRow}
       <div className="space-y-1.5">
         {layers.map((layer) => {
-          const isActive = activeLayerId === layer.id;
+          const isActive = activeLayerIds.includes(layer.id);
           const showInfo = infoLayerId === layer.id;
 
           return (
@@ -114,7 +129,7 @@ export function LayerControls({
               className={isActive ? 'rounded-xl border border-green-200 bg-white shadow-sm overflow-hidden' : ''}
             >
               {/* Layer row */}
-              <div className={`flex items-center gap-2 ${isActive ? 'px-3 py-2.5 bg-green-50' : 'py-2 border-b border-gray-100'}`}>
+              <div className={`flex items-center gap-2 px-3 ${isActive ? 'py-2.5 bg-green-50' : 'py-2 border-b border-gray-100'}`}>
                 {/* Icon */}
                 <div className="size-6 shrink-0 flex items-center justify-center">
                   {layer.icon?.url ? (
@@ -155,8 +170,7 @@ export function LayerControls({
                   aria-checked={isActive}
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (isActive) onLayerDeactivate();
-                    else onLayerChange(layer.id);
+                    onLayerToggle(layer.id);
                   }}
                   className="relative inline-flex h-4 w-8 items-center rounded-full transition-colors shrink-0 focus:outline-none"
                   style={{ backgroundColor: isActive ? '#16803d' : '#d1d5db' }}
@@ -168,24 +182,29 @@ export function LayerControls({
                   />
                 </button>
 
-                {/* Chevron — inactive only */}
-                {!isActive && <ChevronRight className="size-3.5 text-gray-300 shrink-0" />}
+                {/* Chevron — hidden when active to keep layout consistent */}
+                <ChevronRight className={`size-3.5 shrink-0 ${isActive ? 'invisible' : 'text-gray-300'}`} />
               </div>
 
               {/* Selectors (active only) */}
               {isActive && layer.selectors.length > 0 && (
                 <div className="px-3 pb-2 pt-2" onClick={(e) => e.stopPropagation()}>
-                  <div className="flex flex-wrap items-end gap-2" style={{ maxWidth: '85%' }}>
+                  <div className="flex flex-wrap items-end gap-2">
                     {layer.selectors.map((field) => {
                       const selection = selectionValues[layer.id] || {};
                       const options = selectionOptions[layer.id]?.[field.key] || [];
                       const selectedOption = options.find((o) => o.value === selection[field.key]) || null;
+                      // Fall back to first option so the label always reflects what the map renders.
+                      const displayOption = selectedOption ?? options[0] ?? null;
                       const enabled = isFieldEnabled(selection, field);
 
                       if (layer.dataset.cadence === 'annual' && field.key === 'year') {
+                        const yearDisplay = selection.year ?? options[0]?.value;
                         return (
                           <div key={`${layer.id}-${field.key}`} style={{ width: '100%' }}>
-                            <p className="mb-1 text-gray-600" style={{ fontSize: '11px' }}>{field.label[language]}</p>
+                            <p className="mb-1 text-gray-600" style={{ fontSize: '11px' }}>
+                              {field.label[language]}{yearDisplay ? `: ${yearDisplay}` : ''}
+                            </p>
                             <YearSlider
                               options={options}
                               value={selection.year}
@@ -196,13 +215,15 @@ export function LayerControls({
                       }
 
                       return (
-                        <div key={`${layer.id}-${field.key}`} className="flex-1" style={{ minWidth: field.minWidthPx || 100 }}>
-                          <p className="mb-1 text-gray-600" style={{ fontSize: '11px' }}>{field.label[language]}</p>
+                        <div key={`${layer.id}-${field.key}`} style={{ width: 120 }}>
+                          <p className="mb-1 text-gray-600" style={{ fontSize: '11px' }}>
+                            {field.label[language]}{displayOption ? `: ${displayOption.label}` : ''}
+                          </p>
                           <Select
                             className="layer-select"
                             classNamePrefix="layer-select-controls"
                             options={options}
-                            value={selectedOption}
+                            value={null}
                             isClearable={!field.required}
                             isDisabled={!enabled}
                             placeholder={language === 'fr' ? 'Sélectionner..' : 'Select..'}
@@ -221,14 +242,14 @@ export function LayerControls({
                   <div className="border-t border-gray-100 pt-2" style={{ maxWidth: '85%' }}>
                     <div className="flex justify-between text-green-700 mb-1.5" style={{ fontSize: '11px' }}>
                       <span>{t.opacity}</span>
-                      <span>{Math.round(opacity)}%</span>
+                      <span>{Math.round(opacities[layer.id] ?? 85)}%</span>
                     </div>
                     <input
                       type="range"
                       min={0}
                       max={100}
-                      value={opacity}
-                      onChange={(e) => onOpacityChange(Number(e.target.value))}
+                      value={opacities[layer.id] ?? 85}
+                      onChange={(e) => onOpacityChange(layer.id, Number(e.target.value))}
                       className="layer-slider"
                     />
                   </div>

--- a/e-safari-ui/src/components/LayerControls.tsx
+++ b/e-safari-ui/src/components/LayerControls.tsx
@@ -215,7 +215,7 @@ export function LayerControls({
                       }
 
                       return (
-                        <div key={`${layer.id}-${field.key}`} style={{ width: 120 }}>
+                        <div key={`${layer.id}-${field.key}`} style={{ width: field.minWidthPx ?? 120 }}>
                           <p className="mb-1 text-gray-600" style={{ fontSize: '11px' }}>
                             {field.label[language]}{displayOption ? `: ${displayOption.label}` : ''}
                           </p>

--- a/e-safari-ui/src/components/LayerControls.tsx
+++ b/e-safari-ui/src/components/LayerControls.tsx
@@ -242,7 +242,7 @@ export function LayerControls({
                   <div className="border-t border-gray-100 pt-2" style={{ maxWidth: '85%' }}>
                     <div className="flex justify-between text-green-700 mb-1.5" style={{ fontSize: '11px' }}>
                       <span>{t.opacity}</span>
-                      <span>{Math.round(opacities[layer.id] ?? 85)}%</span>
+                      <span>{Math.round(opacities[layer.id] ?? layer.ui?.opacity ?? 85)}%</span>
                     </div>
                     <input
                       type="range"

--- a/e-safari-ui/src/components/LayerControls.tsx
+++ b/e-safari-ui/src/components/LayerControls.tsx
@@ -248,7 +248,7 @@ export function LayerControls({
                       type="range"
                       min={0}
                       max={100}
-                      value={opacities[layer.id] ?? 85}
+                      value={opacities[layer.id] ?? layer.ui?.opacity ?? 85}
                       onChange={(e) => onOpacityChange(layer.id, Number(e.target.value))}
                       className="layer-slider"
                     />

--- a/e-safari-ui/src/components/MobileDrawer.tsx
+++ b/e-safari-ui/src/components/MobileDrawer.tsx
@@ -14,18 +14,17 @@ interface MobileDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   layers: CatalogLayer[];
-  activeLayerId: string | null;
+  activeLayerIds: string[];
   activeLayer: CatalogLayer | null;
-  onLayerChange: (layerId: string) => void;
-  onLayerDeactivate: () => void;
+  onLayerToggle: (layerId: string) => void;
   language: Language;
   selectionValues: Record<string, LayerSelectionValue>;
   selectionOptions: Record<string, Partial<Record<SelectorKey, LayerSelectOption[]>>>;
   onSelectionChange: (layerId: string, field: SelectorKey, value?: string) => void;
   loading?: boolean;
   error?: string | null;
-  opacity: number;
-  onOpacityChange: (value: number) => void;
+  opacities: Record<string, number>;
+  onOpacityChange: (layerId: string, value: number) => void;
 }
 
 const translations = {
@@ -41,17 +40,16 @@ export function MobileDrawer({
   isOpen,
   onClose,
   layers,
-  activeLayerId,
+  activeLayerIds,
   activeLayer,
-  onLayerChange,
-  onLayerDeactivate,
+  onLayerToggle,
   language,
   selectionValues,
   selectionOptions,
   onSelectionChange,
   loading,
   error,
-  opacity,
+  opacities,
   onOpacityChange,
 }: MobileDrawerProps) {
   const t = translations[language];
@@ -65,13 +63,9 @@ export function MobileDrawer({
         <ScrollArea className="h-[calc(85vh-4rem)] mt-4">
           <LayerControls
             layers={layers}
-            activeLayerId={activeLayerId}
-            onLayerChange={(layerId) => {
-              onLayerChange(layerId);
-              onClose();
-            }}
-            onLayerDeactivate={() => {
-              onLayerDeactivate();
+            activeLayerIds={activeLayerIds}
+            onLayerToggle={(layerId) => {
+              onLayerToggle(layerId);
               onClose();
             }}
             language={language}
@@ -80,7 +74,7 @@ export function MobileDrawer({
             onSelectionChange={onSelectionChange}
             loading={loading}
             error={error}
-            opacity={opacity}
+            opacities={opacities}
             onOpacityChange={onOpacityChange}
           />
           <DataPanel activeLayer={activeLayer} language={language} />

--- a/e-safari-ui/src/components/RightBar.jsx
+++ b/e-safari-ui/src/components/RightBar.jsx
@@ -25,12 +25,8 @@ const RightBar = ({ activeLayer, language, selectedFeature, activeTab, onTabChan
                 return <Legend/>;
             case "Analysis":
                 return (
-                    <div>
-                  <DataPanel
-                    activeLayer={activeLayer}
-                    language={language}
-                    selectedFeature={selectedFeature}
-                  />
+                    <div style={{ padding: '24px 16px', textAlign: 'center', color: '#9ca3af', fontSize: '13px' }}>
+                        {language === 'fr' ? 'En cours de développement' : 'Coming soon'}
                     </div>
                 );
             default:

--- a/e-safari-ui/src/components/YearSlider.tsx
+++ b/e-safari-ui/src/components/YearSlider.tsx
@@ -44,7 +44,16 @@ export function YearSlider({ options, value, onChange }: YearSliderProps) {
         return (
           <div
             key={y}
+            role="button"
+            tabIndex={0}
+            aria-label={`Select year ${y}`}
             onClick={() => onChange(String(y))}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onChange(String(y));
+              }
+            }}
             style={{
               position: 'absolute',
               left: `${pct}%`,

--- a/e-safari-ui/src/components/YearSlider.tsx
+++ b/e-safari-ui/src/components/YearSlider.tsx
@@ -13,41 +13,73 @@ export function YearSlider({ options, value, onChange }: YearSliderProps) {
   const min = years[0];
   const max = years[years.length - 1];
   const current = value ? Number(value) : max;
-
-  const listId = `year-ticks-${min}-${max}`;
+  const range = max > min ? max - min : 1;
 
   return (
-    <div style={{ width: '100%' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', color: '#15803d', marginBottom: '2px' }}>
-        <span>{current}</span>
-      </div>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={1}
-        value={current}
-        list={listId}
-        onChange={(e) => {
-          const v = String(e.target.value);
-          // snap to nearest available year
-          const nearest = years.reduce((prev, curr) =>
-            Math.abs(curr - Number(v)) < Math.abs(prev - Number(v)) ? curr : prev,
-          );
-          onChange(String(nearest));
-        }}
-        className="layer-slider"
-      />
-      <datalist id={listId}>
-        {years.map((y) => (
-          <option key={y} value={y} />
-        ))}
-      </datalist>
-      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '10px', color: '#6b7280', marginTop: '2px' }}>
-        {years.map((y) => (
-          <span key={y}>{y}</span>
-        ))}
-      </div>
+    <div style={{ position: 'relative', height: 40, width: '100%' }}>
+      {/* Background track */}
+      <div style={{
+        position: 'absolute',
+        top: 8,
+        left: 0,
+        right: 0,
+        height: 2,
+        borderRadius: 1,
+        backgroundColor: '#bbf7d0',
+      }} />
+      {/* Active fill */}
+      <div style={{
+        position: 'absolute',
+        top: 8,
+        left: 0,
+        width: `${((current - min) / range) * 100}%`,
+        height: 2,
+        borderRadius: 1,
+        backgroundColor: '#15803d',
+      }} />
+      {/* Year dots + labels */}
+      {years.map((y) => {
+        const pct = ((y - min) / range) * 100;
+        const isSelected = y === current;
+        return (
+          <div
+            key={y}
+            onClick={() => onChange(String(y))}
+            style={{
+              position: 'absolute',
+              left: `${pct}%`,
+              top: 0,
+              transform: 'translateX(-50%)',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              cursor: 'pointer',
+            }}
+          >
+            {/* Fixed 16×16 area keeps all labels at the same vertical position */}
+            <div style={{ width: 16, height: 16, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <div style={{
+                width: isSelected ? 14 : 9,
+                height: isSelected ? 14 : 9,
+                borderRadius: '50%',
+                backgroundColor: isSelected ? 'white' : '#15803d',
+                border: isSelected ? '2.5px solid #15803d' : 'none',
+                flexShrink: 0,
+              }} />
+            </div>
+            <span style={{
+              fontSize: '10px',
+              color: isSelected ? '#15803d' : '#9ca3af',
+              fontWeight: isSelected ? 600 : 400,
+              marginTop: 2,
+              whiteSpace: 'nowrap',
+              userSelect: 'none',
+            }}>
+              {y}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/e-safari-ui/src/hooks/useCatalogLayers.ts
+++ b/e-safari-ui/src/hooks/useCatalogLayers.ts
@@ -8,7 +8,13 @@ export function useCatalogLayers(language: Language) {
   const [layers, setLayers] = useState<CatalogLayer[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeLayerId, setActiveLayerId] = useState<string | null>(null);
+  const [activeLayerIds, setActiveLayerIds] = useState<string[]>([]);
+
+  const toggleActiveLayer = useCallback((id: string) => {
+    setActiveLayerIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  }, []);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -28,16 +34,17 @@ export function useCatalogLayers(language: Language) {
         },
       }));
       setLayers(withLang);
-      setActiveLayerId((current) => {
-        if (current && withLang.some((l) => l.id === current)) {
-          return current;
-        }
-        return withLang[0]?.id ?? null;
+      setActiveLayerIds((current) => {
+        // Keep existing active layers that are still present; otherwise default to the first layer.
+        const stillValid = current.filter((id) => withLang.some((l) => l.id === id));
+        if (stillValid.length > 0) return stillValid;
+        const first = withLang[0]?.id;
+        return first ? [first] : [];
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load layers");
       setLayers([]);
-      setActiveLayerId(null);
+      setActiveLayerIds([]);
     } finally {
       setLoading(false);
     }
@@ -47,9 +54,9 @@ export function useCatalogLayers(language: Language) {
     reload();
   }, [reload]);
 
-  const activeLayer = useMemo(
-    () => layers.find((layer) => layer.id === activeLayerId) ?? null,
-    [layers, activeLayerId],
+  const activeLayers = useMemo(
+    () => layers.filter((layer) => activeLayerIds.includes(layer.id)),
+    [layers, activeLayerIds],
   );
 
   const [layerSelections, setLayerSelections] = useState<
@@ -72,9 +79,9 @@ export function useCatalogLayers(language: Language) {
     layers,
     loading,
     error,
-    activeLayerId,
-    activeLayer,
-    setActiveLayerId,
+    activeLayerIds,
+    activeLayers,
+    toggleActiveLayer,
     layerSelections,
     setLayerSelections,
     reload,


### PR DESCRIPTION
Summary
- Multi-layer support — layers now stack instead of replacing each other; toggling a layer on adds its raster tile and legend entry, toggling off removes only that layer. Each active layer has its own independent opacity slider.
- Zoom-to-layer button — a MapLibre-style button below the north arrow fits the map to the union of all active layers' bounds. The map auto-zooms once on initial load, then only on button click.
- Row alignment fix — inactive layer rows now have consistent px-3 horizontal padding and an always-rendered (invisible when active) chevron, keeping the info icon and toggle horizontally aligned across all rows.
- Year slider — replaced the native range input with a custom dot-marker slider; each available year is a clickable dot, selected year shown with a green ring, active fill extends to the current position.
- Date selector UX — selected date/value shown inline in the label (Date: 2026-02); dropdown always shows placeholder so the label is the source of truth.
- Analysis tab — placeholder "Coming soon" text while analysis features are in development.
- CI fixes — resolved RecursionError from legend_description MagicMock leak in tests, and relation "observations" does not exist by wrapping migration SQL in conditional DO $$ IF EXISTS blocks.
