### PR TITLE
feat: add Data Services API reference and dataset URL builder

### DIFF
--- a/multi-hazard-ui/src/App.tsx
+++ b/multi-hazard-ui/src/App.tsx
@@ -7,6 +7,7 @@ import DataPlatforms from './pages/DataPlatforms';
 import DataPlatformDetail from './pages/DataPlatformDetail';
 import Feedback from './pages/Feedback';
 import Partners from './pages/Partners';
+import DataServices from './pages/DataServices';
 
 function App() {
   return (
@@ -15,7 +16,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/geoportal" element={<Geoportal />} />
-          <Route path="/data-services" element={<StubPage title="Data Services" />} />
+          <Route path="/data-services" element={<DataServices />} />
           <Route path="/data-platforms" element={<DataPlatforms />} />
           <Route path="/data-platforms/:datasetId" element={<DataPlatformDetail />} />
           <Route path="/bulletins" element={<StubPage title="Bulletins" />} />

--- a/multi-hazard-ui/src/components/CodeBlock.tsx
+++ b/multi-hazard-ui/src/components/CodeBlock.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { Check, Copy, X } from 'lucide-react';
+
+type CopyState = 'idle' | 'copied' | 'failed';
+
+export function CodeBlock({ code, label }: { code: string; label?: string }) {
+  const [copyState, setCopyState] = useState<CopyState>('idle');
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopyState('copied');
+    } catch {
+      setCopyState('failed');
+    }
+    setTimeout(() => setCopyState('idle'), 1800);
+  }
+
+  return (
+    <div className="relative bg-hub-900 rounded-lg overflow-hidden">
+      {label && (
+        <div className="px-3.5 py-2 text-xs font-semibold text-white/60 border-b border-white/10">{label}</div>
+      )}
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="absolute top-2.5 right-2.5 flex items-center gap-1.5 text-[11px] font-medium px-2 py-1 rounded border border-white/20 text-white/70 hover:text-white hover:border-white/40 transition-colors"
+      >
+        {copyState === 'copied' ? (
+          <>
+            <Check className="size-3" /> Copied
+          </>
+        ) : copyState === 'failed' ? (
+          <>
+            <X className="size-3" /> Couldn't copy
+          </>
+        ) : (
+          <>
+            <Copy className="size-3" /> Copy
+          </>
+        )}
+      </button>
+      <pre className="px-3.5 py-3 pr-20 text-[12px] leading-relaxed text-white/90 font-mono overflow-x-auto whitespace-pre-wrap break-all">
+        {code}
+      </pre>
+    </div>
+  );
+}

--- a/multi-hazard-ui/src/components/NavBar.tsx
+++ b/multi-hazard-ui/src/components/NavBar.tsx
@@ -8,6 +8,7 @@ import norcapLogo from './images/norcap_logo.svg';
 const navLinks = [
   { label: 'HOME', to: '/' },
   { label: 'GEOPORTAL', to: '/geoportal' },
+  { label: 'DATA SERVICES', to: '/data-services' },
   { label: 'DATA PLATFORMS', to: '/data-platforms' },
   { label: 'BULLETINS', to: '/bulletins' },
   { label: 'ABOUT', to: '/about' },

--- a/multi-hazard-ui/src/components/data-services/ApiSidebar.tsx
+++ b/multi-hazard-ui/src/components/data-services/ApiSidebar.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Wrench, Book } from 'lucide-react';
+import type { OpenApiGroup } from '../../types/openApiSchema';
+import type { Selection } from '../../types/dataServices';
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: 'text-hub-400',
+  POST: 'text-amber-500',
+  PUT: 'text-purple-500',
+  PATCH: 'text-purple-500',
+  DELETE: 'text-red-500',
+};
+
+export function ApiSidebar({
+  groups,
+  selected,
+  onSelect,
+}: {
+  groups: OpenApiGroup[];
+  selected: Selection;
+  onSelect: (s: Selection) => void;
+}) {
+  const [openGroups, setOpenGroups] = useState<Set<string>>(new Set(groups.map((g) => g.key)));
+
+  function toggleGroup(key: string) {
+    setOpenGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  return (
+    <nav className="text-sm">
+      <button
+        type="button"
+        onClick={() => onSelect({ type: 'overview' })}
+        className={`w-full flex items-center gap-2 px-3 py-2 rounded-md mb-1 text-left font-medium transition-colors ${
+          selected.type === 'overview' ? 'bg-hub-100 text-hub-800' : 'text-gray-600 hover:bg-gray-50'
+        }`}
+      >
+        <Book className="size-4 shrink-0" />
+        Overview
+      </button>
+
+      <button
+        type="button"
+        onClick={() => onSelect({ type: 'builder' })}
+        className={`w-full flex items-center gap-2 px-3 py-2 rounded-md mb-3 text-left font-medium transition-colors ${
+          selected.type === 'builder' ? 'bg-hub-100 text-hub-800' : 'text-gray-600 hover:bg-gray-50'
+        }`}
+      >
+        <Wrench className="size-4 shrink-0" />
+        Dataset URL builder
+      </button>
+
+      <div className="border-t border-gray-200 pt-3">
+        {groups.map((group) => (
+          <div key={group.key} className="mb-1">
+            <button
+              type="button"
+              onClick={() => toggleGroup(group.key)}
+              className="w-full flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold text-gray-500 uppercase tracking-wide"
+            >
+              {openGroups.has(group.key) ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+              {group.label}
+            </button>
+            {openGroups.has(group.key) && (
+              <div className="ml-2">
+                {group.subgroups.map((subgroup) => (
+                  <div key={subgroup.key} className="mb-1">
+                    {subgroup.label !== 'General' && (
+                      <p className="px-3 py-1 text-[11px] font-semibold text-gray-400">{subgroup.label}</p>
+                    )}
+                    {subgroup.operations.map((op) => (
+                      <button
+                        key={op.operationId}
+                        type="button"
+                        onClick={() => onSelect({ type: 'operation', operationId: op.operationId })}
+                        className={`w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-left transition-colors ${
+                          selected.type === 'operation' && selected.operationId === op.operationId
+                            ? 'bg-hub-100 text-hub-800'
+                            : 'text-gray-600 hover:bg-gray-50'
+                        }`}
+                      >
+                        <span className={`text-[10px] font-bold w-9 shrink-0 ${METHOD_COLORS[op.method] ?? 'text-gray-400'}`}>
+                          {op.method}
+                        </span>
+                        <span className="truncate text-[13px]">{op.summary || op.path}</span>
+                      </button>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/multi-hazard-ui/src/components/data-services/CodeSampleTabs.tsx
+++ b/multi-hazard-ui/src/components/data-services/CodeSampleTabs.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { CodeBlock } from '../CodeBlock';
+import { buildCurlSample, buildFetchSample, buildPythonSample, type SampleRequest } from '../../lib/apiSamples';
+
+const TABS = ['curl', 'JavaScript', 'Python'] as const;
+type Tab = typeof TABS[number];
+
+const BUILDERS: Record<Tab, (req: SampleRequest) => string> = {
+  curl: buildCurlSample,
+  JavaScript: buildFetchSample,
+  Python: buildPythonSample,
+};
+
+export function CodeSampleTabs({ request, label }: { request: SampleRequest; label?: string }) {
+  const [tab, setTab] = useState<Tab>('curl');
+
+  return (
+    <div>
+      {label && <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1.5">{label}</p>}
+      <div className="flex gap-0 mb-0">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className={`text-xs font-medium px-3 py-1.5 rounded-t-md transition-colors ${
+              tab === t ? 'bg-hub-900 text-white' : 'bg-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <CodeBlock code={BUILDERS[tab](request)} />
+    </div>
+  );
+}

--- a/multi-hazard-ui/src/components/data-services/DatasetUrlBuilder.tsx
+++ b/multi-hazard-ui/src/components/data-services/DatasetUrlBuilder.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react';
+import { Search } from 'lucide-react';
+import { useDataPlatformCatalog } from '../../hooks/useDataPlatformCatalog';
+import { fetchDatasetAvailability, fetchDatasetVisualization } from '../../services/layersApi';
+import { availabilityEndpointUrl, notebookUrl, stacCollectionUrl, visualizationEndpointUrl } from '../../lib/datasetUrls';
+import type { CatalogLayer } from '../../types/catalogLayer';
+import { CodeSampleTabs } from './CodeSampleTabs';
+
+export function DatasetUrlBuilder() {
+  const { layers, loading, error } = useDataPlatformCatalog();
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState<CatalogLayer | null>(null);
+
+  const [dates, setDates] = useState<string[]>([]);
+  const [date, setDate] = useState<string | null>(null);
+  const [availabilityLoading, setAvailabilityLoading] = useState(false);
+
+  const [tileUrl, setTileUrl] = useState<string | null>(null);
+  const [tileLoading, setTileLoading] = useState(false);
+
+  const filtered = search
+    ? layers.filter((l) => l.title.toLowerCase().includes(search.toLowerCase()))
+    : layers;
+
+  // Load available dates whenever the selected dataset changes.
+  useEffect(() => {
+    if (!selected) {
+      setDates([]);
+      setDate(null);
+      return;
+    }
+    let cancelled = false;
+    setAvailabilityLoading(true);
+    setDates([]);
+    setDate(null);
+    fetchDatasetAvailability({ datasetId: selected.dataset.id, cadence: selected.dataset.cadence })
+      .then(({ options, max }) => {
+        if (cancelled) return;
+        setDates(options.map((o) => o.value));
+        setDate(max || options[0]?.value || null);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDates([]);
+          setDate(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setAvailabilityLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selected]);
+
+  // Resolve the actual tile URL whenever the selected date changes.
+  useEffect(() => {
+    if (!selected || !date) {
+      setTileUrl(null);
+      return;
+    }
+    let cancelled = false;
+    setTileLoading(true);
+    fetchDatasetVisualization({ datasetId: selected.dataset.id, cadence: selected.dataset.cadence, date })
+      .then(({ tileUrl: resolved }) => {
+        if (!cancelled) setTileUrl(resolved);
+      })
+      .catch(() => {
+        if (!cancelled) setTileUrl(null);
+      })
+      .finally(() => {
+        if (!cancelled) setTileLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selected, date]);
+
+  const visualizationEndpoint = selected && date
+    ? visualizationEndpointUrl(selected.dataset.id, selected.dataset.cadence, date)
+    : null;
+  const availabilityEndpoint = selected
+    ? availabilityEndpointUrl(selected.dataset.id, selected.dataset.cadence)
+    : null;
+  const stacUrl = selected?.details?.has_stac_collection
+    ? stacCollectionUrl(selected.dataset.stac_collection)
+    : null;
+  const notebookEndpoint = selected?.details?.has_notebook
+    ? notebookUrl(selected.dataset.id)
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-bold text-gray-900 mb-1">Dataset URL builder</h2>
+        <p className="text-sm text-gray-600">
+          Pick a dataset to get its ready-to-use API URLs — no API key required.
+        </p>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-6">
+        {/* Dataset picker */}
+        <div>
+          <div className="relative mb-3">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-gray-400" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search datasets..."
+              className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-hub-400"
+            />
+          </div>
+
+          {loading && <p className="text-sm text-gray-500">Loading datasets…</p>}
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <div className="border border-gray-200 rounded-lg max-h-80 overflow-y-auto divide-y divide-gray-100">
+            {filtered.map((layer) => (
+              <button
+                key={layer.dataset.id}
+                type="button"
+                onClick={() => setSelected(layer)}
+                className={`w-full text-left px-3.5 py-2.5 text-sm transition-colors ${
+                  selected?.dataset.id === layer.dataset.id ? 'bg-hub-100 text-hub-800' : 'hover:bg-gray-50 text-gray-700'
+                }`}
+              >
+                <div className="font-medium">{layer.title}</div>
+                <div className="text-xs text-gray-400">{layer.dataset.cadence}</div>
+              </button>
+            ))}
+            {!loading && filtered.length === 0 && (
+              <p className="px-3.5 py-3 text-sm text-gray-400">No datasets match your search.</p>
+            )}
+          </div>
+        </div>
+
+        {/* Date picker */}
+        <div>
+          {!selected ? (
+            <div className="h-full flex items-center justify-center text-sm text-gray-400 border border-dashed border-gray-200 rounded-lg p-6">
+              Select a dataset to configure its request.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div>
+                <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Cadence</p>
+                <p className="text-sm text-gray-800">{selected.dataset.cadence}</p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Date</p>
+                {availabilityLoading ? (
+                  <p className="text-sm text-gray-400">Loading available dates…</p>
+                ) : dates.length === 0 ? (
+                  <p className="text-sm text-gray-400">No available dates for this dataset.</p>
+                ) : (
+                  <select
+                    value={date ?? ''}
+                    onChange={(e) => setDate(e.target.value)}
+                    className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-hub-400"
+                  >
+                    {dates.map((d) => (
+                      <option key={d} value={d}>{d}</option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {selected && (
+        <div className="space-y-5 pt-2 border-t border-gray-200">
+          {visualizationEndpoint && (
+            <CodeSampleTabs
+              request={{ method: 'GET', url: visualizationEndpoint }}
+              label="Visualization API endpoint"
+            />
+          )}
+
+          {tileLoading && <p className="text-xs text-gray-400">Resolving tile URL…</p>}
+          {tileUrl && (
+            <div>
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1.5">
+                Resolved tile URL (for map clients)
+              </p>
+              <pre className="px-3.5 py-3 text-[12px] leading-relaxed text-white/90 font-mono bg-hub-900 rounded-lg overflow-x-auto whitespace-pre-wrap break-all">
+                {tileUrl}
+              </pre>
+            </div>
+          )}
+
+          {availabilityEndpoint && (
+            <CodeSampleTabs request={{ method: 'GET', url: availabilityEndpoint }} label="Availability endpoint" />
+          )}
+
+          {stacUrl && <CodeSampleTabs request={{ method: 'GET', url: stacUrl }} label="STAC collection URL" />}
+
+          {notebookEndpoint && (
+            <CodeSampleTabs request={{ method: 'GET', url: notebookEndpoint }} label="Example notebook URL" />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/multi-hazard-ui/src/components/data-services/OperationPanel.tsx
+++ b/multi-hazard-ui/src/components/data-services/OperationPanel.tsx
@@ -1,0 +1,68 @@
+import { catalogBaseUrl } from '../../config/api';
+import type { OpenApiOperation } from '../../types/openApiSchema';
+import { CodeSampleTabs } from './CodeSampleTabs';
+
+const METHOD_BADGE: Record<string, string> = {
+  GET: 'bg-hub-100 text-hub-700',
+  POST: 'bg-amber-100 text-amber-700',
+  PUT: 'bg-purple-100 text-purple-700',
+  PATCH: 'bg-purple-100 text-purple-700',
+  DELETE: 'bg-red-100 text-red-700',
+};
+
+function placeholderUrl(operation: OpenApiOperation): string {
+  const pathWithPlaceholders = operation.path.replace(/\{([^}]+)\}/g, (_match, name) => `<${name}>`);
+  const queryParams = operation.parameters.filter((p) => p.in === 'query');
+  if (queryParams.length === 0) return `${catalogBaseUrl}${pathWithPlaceholders}`;
+  const query = queryParams.map((p) => `${p.name}=<${p.name}>`).join('&');
+  return `${catalogBaseUrl}${pathWithPlaceholders}?${query}`;
+}
+
+export function OperationPanel({ operation }: { operation: OpenApiOperation }) {
+  const url = placeholderUrl(operation);
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <span className={`text-[11px] font-bold px-2 py-0.5 rounded ${METHOD_BADGE[operation.method] ?? 'bg-gray-100 text-gray-700'}`}>
+            {operation.method}
+          </span>
+          <code className="text-sm text-gray-800 font-mono">{operation.path}</code>
+        </div>
+        {operation.summary && <h2 className="text-lg font-bold text-gray-900">{operation.summary}</h2>}
+        {operation.description && (
+          <p className="text-sm text-gray-600 mt-1.5 leading-relaxed">{operation.description}</p>
+        )}
+      </div>
+
+      {operation.parameters.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Parameters</p>
+          <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left px-3 py-2 font-semibold text-gray-600">Name</th>
+                <th className="text-left px-3 py-2 font-semibold text-gray-600">In</th>
+                <th className="text-left px-3 py-2 font-semibold text-gray-600">Required</th>
+                <th className="text-left px-3 py-2 font-semibold text-gray-600">Description</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {operation.parameters.map((p) => (
+                <tr key={`${p.in}:${p.name}`}>
+                  <td className="px-3 py-2 font-mono text-xs text-gray-800">{p.name}</td>
+                  <td className="px-3 py-2 text-gray-500">{p.in}</td>
+                  <td className="px-3 py-2 text-gray-500">{p.required ? 'Yes' : 'No'}</td>
+                  <td className="px-3 py-2 text-gray-600">{p.description || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <CodeSampleTabs request={{ method: operation.method, url }} label="Example request" />
+    </div>
+  );
+}

--- a/multi-hazard-ui/src/hooks/useOpenApiSchema.ts
+++ b/multi-hazard-ui/src/hooks/useOpenApiSchema.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import type { OpenApiGroup } from "../types/openApiSchema";
+import { fetchOpenApiSchema, groupOperations } from "../services/openApiSchema";
+
+export function useOpenApiSchema() {
+  const [groups, setGroups] = useState<OpenApiGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchOpenApiSchema()
+      .then((schema) => {
+        if (cancelled) return;
+        setGroups(groupOperations(schema));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load API schema");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { groups, loading, error };
+}

--- a/multi-hazard-ui/src/lib/apiSamples.ts
+++ b/multi-hazard-ui/src/lib/apiSamples.ts
@@ -1,0 +1,20 @@
+export type SampleRequest = {
+  method: string;
+  url: string;
+};
+
+export function buildCurlSample({ method, url }: SampleRequest): string {
+  const flag = method.toUpperCase() === "GET" ? "" : ` -X ${method.toUpperCase()}`;
+  return `curl${flag} "${url}"`;
+}
+
+export function buildFetchSample({ method, url }: SampleRequest): string {
+  const methodLine = method.toUpperCase() === "GET" ? "" : `, { method: "${method.toUpperCase()}" }`;
+  return `fetch("${url}"${methodLine})\n  .then((res) => res.json())\n  .then((data) => console.log(data));`;
+}
+
+export function buildPythonSample({ method, url }: SampleRequest): string {
+  const call = method.toUpperCase() === "GET" ? "requests.get" : `requests.request`;
+  const args = method.toUpperCase() === "GET" ? `"${url}"` : `"${method.toUpperCase()}", "${url}"`;
+  return `import requests\n\nresponse = ${call}(${args})\nprint(response.json())`;
+}

--- a/multi-hazard-ui/src/lib/datasetUrls.ts
+++ b/multi-hazard-ui/src/lib/datasetUrls.ts
@@ -1,0 +1,17 @@
+import { catalogBaseUrl } from "../config/api";
+
+export function visualizationEndpointUrl(datasetId: string, cadence: string, date: string): string {
+  return `${catalogBaseUrl}/api/catalog/datasets/${datasetId}/visualization/?date=${date}&cadence=${cadence}`;
+}
+
+export function availabilityEndpointUrl(datasetId: string, cadence: string): string {
+  return `${catalogBaseUrl}/api/catalog/datasets/${datasetId}/availability/?cadence=${cadence}`;
+}
+
+export function stacCollectionUrl(stacCollection: string): string {
+  return `${catalogBaseUrl}/stac/collections/${stacCollection}`;
+}
+
+export function notebookUrl(datasetId: string): string {
+  return `${catalogBaseUrl}/api/catalog/datasets/${datasetId}/notebook/`;
+}

--- a/multi-hazard-ui/src/pages/DataServices.tsx
+++ b/multi-hazard-ui/src/pages/DataServices.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { Terminal, ShieldCheck, ExternalLink } from 'lucide-react';
+import NavBar from '../components/NavBar';
+import { ApiSidebar } from '../components/data-services/ApiSidebar';
+import { OperationPanel } from '../components/data-services/OperationPanel';
+import { DatasetUrlBuilder } from '../components/data-services/DatasetUrlBuilder';
+import { useOpenApiSchema } from '../hooks/useOpenApiSchema';
+import { catalogBaseUrl } from '../config/api';
+import type { Selection } from '../types/dataServices';
+
+function Overview() {
+  return (
+    <div className="space-y-5 max-w-2xl">
+      <h2 className="text-lg font-bold text-gray-900">Multi-Hazard Hub API</h2>
+      <p className="text-sm text-gray-600 leading-relaxed">
+        Browse the public catalog, dataset, and station endpoints on the left, or jump straight to the{' '}
+        <span className="font-semibold text-hub-700">Dataset URL builder</span> to pick a dataset and get its
+        ready-to-use API URLs.
+      </p>
+      <div className="flex items-start gap-3 bg-hub-100 border border-hub-400/30 rounded-lg px-4 py-3.5">
+        <ShieldCheck className="size-5 text-hub-700 shrink-0 mt-0.5" />
+        <div className="text-sm text-hub-800">
+          <p className="font-semibold mb-0.5">No API key required</p>
+          <p className="text-hub-700/80">These endpoints are public — no authentication header is needed today.</p>
+        </div>
+      </div>
+      <a
+        href={`${catalogBaseUrl}/api/docs/`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-hub-700 hover:text-hub-400"
+      >
+        Full interactive schema (Swagger) <ExternalLink className="size-3.5" />
+      </a>
+    </div>
+  );
+}
+
+export default function DataServices() {
+  const { groups, loading, error } = useOpenApiSchema();
+  const [selected, setSelected] = useState<Selection>({ type: 'overview' });
+
+  const selectedOperation = selected.type === 'operation'
+    ? groups
+      .flatMap((g) => g.subgroups)
+      .flatMap((sg) => sg.operations)
+      .find((op) => op.operationId === selected.operationId)
+    : null;
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <NavBar />
+
+      <section className="relative pt-2 pb-4 px-6 bg-hub-900 text-white">
+        <div
+          className="absolute top-0 left-0 right-0 h-1"
+          style={{ background: 'linear-gradient(90deg, #33CD33, #F3D545)' }}
+        />
+        <div className="max-w-6xl mx-auto py-6">
+          <div className="flex items-center gap-2 text-hub-400 text-sm font-semibold uppercase tracking-wide mb-3">
+            <Terminal className="size-4" /> Data Services
+          </div>
+          <h1 className="text-3xl font-bold mb-2">Access APIs, data downloads, and programmatic services</h1>
+          <p className="text-gray-300 max-w-2xl leading-relaxed">
+            Reference for the Multi-Hazard Hub's public API, plus a dataset URL builder to get a ready-to-use
+            request for any dataset in the catalog.
+          </p>
+        </div>
+      </section>
+
+      <section className="flex-1 px-6 py-8 bg-white">
+        <div className="max-w-6xl mx-auto grid md:grid-cols-[240px_1fr] gap-8">
+          <aside className="md:sticky md:top-4 md:self-start">
+            {loading && <p className="text-sm text-gray-400 px-3">Loading endpoints…</p>}
+            {error && <p className="text-sm text-red-600 px-3">{error}</p>}
+            {!loading && !error && <ApiSidebar groups={groups} selected={selected} onSelect={setSelected} />}
+          </aside>
+
+          <main>
+            {selected.type === 'overview' && <Overview />}
+            {selected.type === 'builder' && <DatasetUrlBuilder />}
+            {selected.type === 'operation' && selectedOperation && (
+              <OperationPanel operation={selectedOperation} />
+            )}
+            {selected.type === 'operation' && !selectedOperation && !loading && (
+              <p className="text-sm text-gray-400">Endpoint not found.</p>
+            )}
+          </main>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/multi-hazard-ui/src/pages/Geoportal.tsx
+++ b/multi-hazard-ui/src/pages/Geoportal.tsx
@@ -24,6 +24,7 @@ import {
 import type { CatalogLayer } from '../types/catalogLayer';
 import type { BoundsObject } from '../services/layersApi';
 import { inferCategory } from '../lib/inferCategory';
+import { visualizationEndpointUrl } from '../lib/datasetUrls';
 
 // ---------------------------------------------------------------------------
 // Hazard categories — loaded from backend, fallback to hardcoded list
@@ -52,9 +53,22 @@ function RightPanel({ layer, isActive, onClose, onToggle, onOpacityChange, opaci
   const [vizDate, setVizDate] = useState<string | null>(null);
   const [dateIndex, setDateIndex] = useState(0);
   const [availError, setAvailError] = useState(false);
+  const [linkCopied, setLinkCopied] = useState(false);
   const { mapRef } = useMap() ?? { mapRef: { current: null } };
 
   const cadence = layer.dataset.cadence;
+
+  const handleCopyApiLink = async () => {
+    const date = availability[dateIndex] ?? vizDate ?? maxDate;
+    if (!date) return;
+    try {
+      await navigator.clipboard.writeText(visualizationEndpointUrl(layer.dataset.id, cadence, date));
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 1800);
+    } catch {
+      // clipboard unavailable (e.g. insecure context) — button label stays as-is
+    }
+  };
 
   // Load availability when the layer changes
   useEffect(() => {
@@ -305,8 +319,21 @@ function FullDetailsDialog({
   availability, dateIndex, currentDateLabel, onDateNav,
 }: FullDetailsDialogProps) {
   const [activeTab, setActiveTab] = useState<DetailTab>('Overview');
+  const [linkCopied, setLinkCopied] = useState(false);
   const categoryKey = inferCategory(layer);
   const hazardCat = categories.find((c) => c.key === categoryKey);
+
+  const handleCopyApiLink = async () => {
+    const date = availability[dateIndex];
+    if (!date) return;
+    try {
+      await navigator.clipboard.writeText(visualizationEndpointUrl(layer.dataset.id, layer.dataset.cadence, date));
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 1800);
+    } catch {
+      // clipboard unavailable (e.g. insecure context) — button label stays as-is
+    }
+  };
 
   const badgeColors: Record<string, string> = {
     drought: 'bg-amber-100 text-amber-700',
@@ -446,8 +473,11 @@ function FullDetailsDialog({
                   <button className="flex-1 flex items-center justify-center gap-1.5 border border-gray-300 text-gray-700 hover:border-hub-400 rounded px-3 py-2 text-sm font-medium">
                     <Download className="size-4" /> Download
                   </button>
-                  <button className="flex-1 flex items-center justify-center gap-1.5 border border-gray-300 text-gray-700 hover:border-hub-400 rounded px-3 py-2 text-sm font-medium">
-                    <Copy className="size-4" /> Copy API Link
+                  <button
+                    onClick={handleCopyApiLink}
+                    className="flex-1 flex items-center justify-center gap-1.5 border border-gray-300 text-gray-700 hover:border-hub-400 rounded px-3 py-2 text-sm font-medium"
+                  >
+                    <Copy className="size-4" /> {linkCopied ? 'Copied!' : 'Copy API Link'}
                   </button>
                 </div>
                 {hazardCat?.external_system_url && (
@@ -600,8 +630,11 @@ function FullDetailsDialog({
               <button className="w-full flex items-center justify-center gap-2 border border-gray-300 text-gray-700 hover:border-hub-400 hover:text-hub-700 rounded px-4 py-2.5 text-sm font-medium transition-colors">
                 <Download className="size-4" /> Download
               </button>
-              <button className="w-full flex items-center justify-center gap-2 border border-gray-300 text-gray-700 hover:border-hub-400 hover:text-hub-700 rounded px-4 py-2.5 text-sm font-medium transition-colors">
-                <Copy className="size-4" /> Copy API Link
+              <button
+                onClick={handleCopyApiLink}
+                className="w-full flex items-center justify-center gap-2 border border-gray-300 text-gray-700 hover:border-hub-400 hover:text-hub-700 rounded px-4 py-2.5 text-sm font-medium transition-colors"
+              >
+                <Copy className="size-4" /> {linkCopied ? 'Copied!' : 'Copy API Link'}
               </button>
               {hazardCat?.external_system_url && (
                 <a

--- a/multi-hazard-ui/src/services/openApiSchema.ts
+++ b/multi-hazard-ui/src/services/openApiSchema.ts
@@ -1,0 +1,114 @@
+import axios from "axios";
+import { catalogBaseUrl } from "../config/api";
+import type {
+  OpenApiGroup,
+  OpenApiOperation,
+  OpenApiParameter,
+  OpenApiSubgroup,
+  RawOpenApiOperation,
+  RawOpenApiParameter,
+  RawOpenApiSchema,
+} from "../types/openApiSchema";
+
+const PUBLIC_PATH_PREFIXES = ["/api/catalog/"];
+const HTTP_METHODS = ["get"] as const;
+
+// Project-level endpoints (config, countries) are hidden from the reference for now —
+// only the dataset/catalog-browsing endpoints are shown.
+const EXCLUDED_PATHS = new Set([
+  "/api/catalog/projects/{slug}/config/",
+  "/api/catalog/projects/{slug}/countries/",
+]);
+
+const client = axios.create({ baseURL: catalogBaseUrl, timeout: 15000 });
+
+export async function fetchOpenApiSchema(): Promise<RawOpenApiSchema> {
+  const response = await client.get<RawOpenApiSchema>("/api/schema/", {
+    params: { format: "json" },
+  });
+  return response.data;
+}
+
+function toParameter(raw: RawOpenApiParameter): OpenApiParameter {
+  return {
+    name: raw.name,
+    in: raw.in,
+    required: Boolean(raw.required),
+    description: raw.description,
+    schema: raw.schema,
+  };
+}
+
+function mergeParameters(
+  pathLevel: RawOpenApiParameter[],
+  operationLevel: RawOpenApiParameter[],
+): OpenApiParameter[] {
+  const byKey = new Map<string, RawOpenApiParameter>();
+  for (const p of pathLevel) byKey.set(`${p.in}:${p.name}`, p);
+  for (const p of operationLevel) byKey.set(`${p.in}:${p.name}`, p);
+  return Array.from(byKey.values()).map(toParameter);
+}
+
+function humanize(segment: string): string {
+  const withSpaces = segment.replace(/[-_]/g, " ");
+  return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
+}
+
+function isPathParam(segment: string): boolean {
+  return segment.startsWith("{") && segment.endsWith("}");
+}
+
+/** Groups public, GET-only catalog operations for the sidebar: primary group = first
+ * segment after `/api/`, secondary group = first literal (non-`{param}`) segment
+ * after that, falling back to "General" when the path has none. Stations,
+ * observations, and project config/countries are excluded for now. */
+export function groupOperations(schema: RawOpenApiSchema): OpenApiGroup[] {
+  const groups = new Map<string, { label: string; subgroups: Map<string, OpenApiSubgroup> }>();
+
+  for (const [path, pathItem] of Object.entries(schema.paths || {})) {
+    if (!PUBLIC_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))) continue;
+    if (EXCLUDED_PATHS.has(path)) continue;
+
+    const segments = path.split("/").filter(Boolean);
+    const primaryKey = segments[1];
+    if (!primaryKey) continue;
+
+    const secondarySegment = segments.slice(2).find((s) => !isPathParam(s));
+    const secondaryKey = secondarySegment ?? "general";
+    const secondaryLabel = secondarySegment ? humanize(secondarySegment) : "General";
+
+    for (const method of HTTP_METHODS) {
+      const op: RawOpenApiOperation | undefined = pathItem[method];
+      if (!op) continue;
+
+      const operation: OpenApiOperation = {
+        operationId: op.operationId ?? `${method}_${path}`,
+        method: method.toUpperCase(),
+        path,
+        summary: op.summary,
+        description: op.description,
+        tags: op.tags ?? [primaryKey],
+        parameters: mergeParameters(pathItem.parameters ?? [], op.parameters ?? []),
+      };
+
+      if (!groups.has(primaryKey)) {
+        groups.set(primaryKey, { label: humanize(primaryKey), subgroups: new Map() });
+      }
+      const group = groups.get(primaryKey)!;
+      if (!group.subgroups.has(secondaryKey)) {
+        group.subgroups.set(secondaryKey, { key: secondaryKey, label: secondaryLabel, operations: [] });
+      }
+      group.subgroups.get(secondaryKey)!.operations.push(operation);
+    }
+  }
+
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, { label, subgroups }]) => ({
+      key,
+      label,
+      subgroups: Array.from(subgroups.values())
+        .sort((a, b) => a.label.localeCompare(b.label))
+        .map((sg) => ({ ...sg, operations: [...sg.operations].sort((a, b) => a.path.localeCompare(b.path)) })),
+    }));
+}

--- a/multi-hazard-ui/src/types/dataServices.ts
+++ b/multi-hazard-ui/src/types/dataServices.ts
@@ -1,0 +1,4 @@
+export type Selection =
+  | { type: 'overview' }
+  | { type: 'builder' }
+  | { type: 'operation'; operationId: string };

--- a/multi-hazard-ui/src/types/openApiSchema.ts
+++ b/multi-hazard-ui/src/types/openApiSchema.ts
@@ -1,0 +1,56 @@
+export type OpenApiParamLocation = 'path' | 'query' | 'header' | 'cookie';
+
+export type OpenApiParameter = {
+  name: string;
+  in: OpenApiParamLocation;
+  required: boolean;
+  description?: string;
+  schema?: { type?: string; format?: string; enum?: string[] };
+};
+
+export type OpenApiOperation = {
+  operationId: string;
+  method: string;
+  path: string;
+  summary?: string;
+  description?: string;
+  tags: string[];
+  parameters: OpenApiParameter[];
+};
+
+export type OpenApiSubgroup = {
+  key: string;
+  label: string;
+  operations: OpenApiOperation[];
+};
+
+export type OpenApiGroup = {
+  key: string;
+  label: string;
+  subgroups: OpenApiSubgroup[];
+};
+
+/** Minimal shape of the parts of the raw OpenAPI 3 document this app reads. */
+export type RawOpenApiParameter = {
+  name: string;
+  in: OpenApiParamLocation;
+  required?: boolean;
+  description?: string;
+  schema?: { type?: string; format?: string; enum?: string[] };
+};
+
+export type RawOpenApiOperation = {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: RawOpenApiParameter[];
+};
+
+export type RawOpenApiPathItem = {
+  parameters?: RawOpenApiParameter[];
+} & Partial<Record<'get' | 'post' | 'put' | 'patch' | 'delete', RawOpenApiOperation>>;
+
+export type RawOpenApiSchema = {
+  paths: Record<string, RawOpenApiPathItem>;
+};


### PR DESCRIPTION
Adds a Vultr-Inference-docs-style /data-services page that renders the public catalog API live from the OpenAPI schema (no hand-maintained docs to drift), plus a dataset URL builder that resolves a chosen dataset's visualization, availability, STAC, and notebook URLs. Also wires up the previously dead "Copy API Link" buttons in Geoportal.

Stations, observations, and project config/countries endpoints are excluded from the reference for now.