### PR TITLE
fix: restore API key auth on upload/ingest endpoints

### DIFF
--- a/ingest/api.py
+++ b/ingest/api.py
@@ -1,14 +1,13 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from datetime import datetime, date
 
 from catalog.models import DatasetPage
-# from .auth import HeaderAPIKeyAuthentication
+from .auth import HeaderAPIKeyAuthentication
 from .models import IngestionRun
-# from .permissions import HasAPIKey
+from .permissions import HasAPIKey
 from .serializers import IngestRequestSerializer, IngestResponseSerializer
 
 from .tasks import process_ingestion_run
@@ -49,8 +48,8 @@ class IngestDatasetItemView(APIView):
     It validates the S3 path, creates necessary STAC collections,
     and posts the item metadata to the pgSTAC catalog.
     """
-    # authentication_classes = [HeaderAPIKeyAuthentication]
-    permission_classes = [IsAuthenticated]
+    authentication_classes = [HeaderAPIKeyAuthentication]
+    permission_classes = [HasAPIKey]
 
     @extend_schema(
         request=IngestRequestSerializer,

--- a/ingest/tests.py
+++ b/ingest/tests.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from ingest.models import DeletionRun, IngestionRun
+from ingest.models import APIKey, DeletionRun, IngestionRun
 from ingest.tasks import build_item
 from ingest.stac_ops import derive_item_id
 
@@ -54,8 +54,8 @@ class IngestionSubmitViewTests(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.user = User.objects.create_user("ingest_user", password="pass")
-        self.client.force_authenticate(user=self.user)
+        self.api_key = APIKey.objects.create(name="ingest_user")
+        self.client.credentials(HTTP_X_API_KEY=self.api_key.key)
 
     def test_returns_403_without_authentication(self):
         anon = APIClient()

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -31,8 +31,6 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-API-KEY $http_x_api_key;
-
             proxy_set_header X-API-Key $http_x_api_key;
         }
 
@@ -42,8 +40,6 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-API-KEY $http_x_api_key;
-
             proxy_set_header X-API-Key $http_x_api_key;
         }
 

--- a/nginx/default_pre_ssl.conf
+++ b/nginx/default_pre_ssl.conf
@@ -33,7 +33,6 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-API-KEY $http_x_api_key;
             proxy_set_header X-API-Key $http_x_api_key;
         }
 
@@ -43,7 +42,6 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-API-KEY $http_x_api_key;
             proxy_set_header X-API-Key $http_x_api_key;
         }
 

--- a/nginx/default_ssl.conf
+++ b/nginx/default_ssl.conf
@@ -34,8 +34,6 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-API-KEY $http_x_api_key;
-
             proxy_set_header X-API-Key $http_x_api_key;
         }
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,8 +36,6 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-API-KEY $http_x_api_key;
-
             proxy_set_header X-API-Key $http_x_api_key;
         }
 
@@ -47,8 +45,6 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-API-KEY $http_x_api_key;
-
             proxy_set_header X-API-Key $http_x_api_key;
         }
 

--- a/uploads/tests.py
+++ b/uploads/tests.py
@@ -3,14 +3,11 @@ import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
-from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from ingest.models import IngestionRun
-
-User = get_user_model()
+from ingest.models import APIKey, IngestionRun
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -46,8 +43,8 @@ class PresignUploadViewTests(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.user = User.objects.create_user("upload_user", password="pass")
-        self.client.force_authenticate(user=self.user)
+        self.api_key = APIKey.objects.create(name="upload_user")
+        self.client.credentials(HTTP_X_API_KEY=self.api_key.key)
 
     def test_returns_403_without_authentication(self):
         anon = APIClient()
@@ -104,8 +101,8 @@ class DirectUploadViewTests(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.user = User.objects.create_user("direct_user", password="pass")
-        self.client.force_authenticate(user=self.user)
+        self.api_key = APIKey.objects.create(name="direct_user")
+        self.client.credentials(HTTP_X_API_KEY=self.api_key.key)
 
     def test_returns_403_without_authentication(self):
         anon = APIClient()
@@ -155,8 +152,8 @@ class DirectUploadViewTests(TestCase):
 class UploadStatusViewTests(TestCase):
     def setUp(self):
         self.client = APIClient()
-        self.user = User.objects.create_user("status_user", password="pass")
-        self.client.force_authenticate(user=self.user)
+        self.api_key = APIKey.objects.create(name="status_user")
+        self.client.credentials(HTTP_X_API_KEY=self.api_key.key)
 
     def test_pending_task_returns_status_pending(self):
         task_id = "abc-123"

--- a/uploads/views.py
+++ b/uploads/views.py
@@ -18,11 +18,10 @@ from .serializers import (
 )
 from .storage.minio import minio_client
 from .tasks import upload_file_to_minio
-# from ingest.auth import HeaderAPIKeyAuthentication
-# from ingest.permissions import HasAPIKey
+from ingest.auth import HeaderAPIKeyAuthentication
+from ingest.permissions import HasAPIKey
 from catalog.models import DatasetPage
 from ingest.api import validate_payload_for_cadence
-from rest_framework.permissions import IsAuthenticated
 from drf_spectacular.utils import extend_schema
 
 
@@ -39,8 +38,8 @@ class PresignUploadView(APIView):
     """
     Returns a pre-signed PUT url for direct upload to MinIO + the resulting s3:// href.
     """
-    # authentication_classes = [HeaderAPIKeyAuthentication]
-    permission_classes = [IsAuthenticated]
+    authentication_classes = [HeaderAPIKeyAuthentication]
+    permission_classes = [HasAPIKey]
 
     @extend_schema(
         request=PresignUploadRequestSerializer,
@@ -110,8 +109,8 @@ class DirectUpFileUploadView(APIView):
     Returns a task ID that can be used to check upload status.
     """
     parser_classes = (MultiPartParser, FormParser)
-    # authentication_classes = [HeaderAPIKeyAuthentication]
-    permission_classes = [IsAuthenticated]
+    authentication_classes = [HeaderAPIKeyAuthentication]
+    permission_classes = [HasAPIKey]
 
     @extend_schema(
         request=DirectUploadRequestSerializer,
@@ -252,7 +251,8 @@ class UploadStatusView(APIView):
     """
     Check the status of an async upload task.
     """
-    permission_classes = [IsAuthenticated]
+    authentication_classes = [HeaderAPIKeyAuthentication]
+    permission_classes = [HasAPIKey]
 
     @extend_schema(
         responses={200: UploadStatusResponseSerializer},


### PR DESCRIPTION
authentication_classes = [HeaderAPIKeyAuthentication] was commented out on PresignUploadView, DirectUpFileUploadView, UploadStatusView (uploads/views.py) and IngestDatasetItemView (ingest/api.py) since the Feb 10 nginx/minio commit, leaving them on IsAuthenticated with no working non-interactive auth path (no session, no working API key). Restored HeaderAPIKeyAuthentication + HasAPIKey, matching the original "keep your existing API key auth here" design.

Also fixes a real nginx bug found while testing the above: X-API-Key was set twice per location block with different casing (X-API-KEY and X-API-Key), which nginx treats as two separate headers — Django's WSGI layer then merges same-name headers into one comma-joined value, so even a correct key never matched anything (confirmed by logging the literal duplicated value server-side before removing the debug line). Fixed in default.conf, default_pre_ssl.conf, nginx.conf, and default_ssl.conf's e-safari.acmad.org block (multi-hazard.acmad.org's block only had it once already, so left as-is there).

Verified locally end-to-end: created a fresh APIKey via the local DB, confirmed the request now authenticates through the full nginx -> Django path (previously 403 either way; now correctly reaches a 404 "Unknown dataset_id" for a dataset that only exists in production's catalog, not local).