### PR TITLE
feat: support DRF token auth alongside API key on ingest/upload/delet…

### DIFF
--- a/ingest/api.py
+++ b/ingest/api.py
@@ -1,6 +1,7 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.authentication import TokenAuthentication
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from datetime import datetime, date
 
@@ -11,6 +12,10 @@ from .permissions import HasAPIKey
 from .serializers import IngestRequestSerializer, IngestResponseSerializer
 
 from .tasks import process_ingestion_run
+
+# Either an APIKey (X-API-Key) or a DRF Token (Authorization: Token ...)
+# authenticates — see ingest.permissions.HasAPIKey.
+KEY_OR_TOKEN_AUTH = [HeaderAPIKeyAuthentication, TokenAuthentication]
 
 
 def _json_safe(value):
@@ -48,7 +53,7 @@ class IngestDatasetItemView(APIView):
     It validates the S3 path, creates necessary STAC collections,
     and posts the item metadata to the pgSTAC catalog.
     """
-    authentication_classes = [HeaderAPIKeyAuthentication]
+    authentication_classes = KEY_OR_TOKEN_AUTH
     permission_classes = [HasAPIKey]
 
     @extend_schema(

--- a/ingest/delete_api.py
+++ b/ingest/delete_api.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from catalog.models import DatasetPage
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .api import _json_safe, validate_payload_for_cadence
+from .api import _json_safe, validate_payload_for_cadence, KEY_OR_TOKEN_AUTH
 from .models import DeletionRun
+from .permissions import HasAPIKey
 from .serializers import DeleteByDatetimeSerializer, DeleteResponseSerializer
 from .stac_ops import resolve_item_ids_for_delete
 from .tasks import process_deletion_run
@@ -53,7 +53,8 @@ _DELETE_OBJECT_PARAM = OpenApiParameter(
 class DeleteDatasetItemView(APIView):
     """Delete a single STAC item by id (optional MinIO purge)."""
 
-    permission_classes = [IsAuthenticated]
+    authentication_classes = KEY_OR_TOKEN_AUTH
+    permission_classes = [HasAPIKey]
 
     @extend_schema(
         responses={202: DeleteResponseSerializer},
@@ -106,7 +107,8 @@ class DeleteDatasetItemView(APIView):
 class DeleteDatasetItemByDatetimeView(APIView):
     """Delete a STAC item identified by datetime (optional MinIO purge)."""
 
-    permission_classes = [IsAuthenticated]
+    authentication_classes = KEY_OR_TOKEN_AUTH
+    permission_classes = [HasAPIKey]
 
     @extend_schema(
         request=DeleteByDatetimeSerializer,

--- a/ingest/permissions.py
+++ b/ingest/permissions.py
@@ -3,7 +3,11 @@ from rest_framework.permissions import BasePermission
 
 class HasAPIKey(BasePermission):
     """
-    Allows access only when HeaderAPIKeyAuthentication succeeded.
+    Allows access when either HeaderAPIKeyAuthentication (X-API-Key) or
+    DRF's TokenAuthentication (Authorization: Token ...) succeeded — both
+    populate request.auth on success (an APIKey instance or a Token
+    instance respectively), so this check works for either without caring
+    which one actually authenticated the request.
     """
     def has_permission(self, request, view):
         return request.auth is not None

--- a/ingest/tests.py
+++ b/ingest/tests.py
@@ -1,15 +1,12 @@
 from unittest.mock import MagicMock, patch
 
 import botocore.exceptions
-from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework.test import APIClient
 
 from ingest.models import APIKey, DeletionRun, IngestionRun
 from ingest.tasks import build_item
 from ingest.stac_ops import derive_item_id
-
-User = get_user_model()
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -359,8 +356,8 @@ class DeleteDatasetItemViewTests(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.user = User.objects.create_user("delete_user", password="pass")
-        self.client.force_authenticate(user=self.user)
+        self.api_key = APIKey.objects.create(name="delete_user")
+        self.client.credentials(HTTP_X_API_KEY=self.api_key.key)
 
     @patch("ingest.delete_api.process_deletion_run")
     @patch("ingest.delete_api._get_dataset")

--- a/uploads/views.py
+++ b/uploads/views.py
@@ -6,6 +6,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.parsers import MultiPartParser, FormParser
+from rest_framework.authentication import TokenAuthentication
 from django.core.cache import cache
 from django.conf import settings
 
@@ -24,6 +25,11 @@ from catalog.models import DatasetPage
 from ingest.api import validate_payload_for_cadence
 from drf_spectacular.utils import extend_schema
 
+# Either an APIKey (X-API-Key header, Ingest > Api keys in admin) or a DRF
+# Token (Authorization: Token ... header, Tokens in admin, auto-generated
+# per user) authenticates — see ingest.permissions.HasAPIKey.
+_KEY_OR_TOKEN_AUTH = [HeaderAPIKeyAuthentication, TokenAuthentication]
+
 
 def _json_safe(value):
     if isinstance(value, (datetime, date)):
@@ -38,7 +44,7 @@ class PresignUploadView(APIView):
     """
     Returns a pre-signed PUT url for direct upload to MinIO + the resulting s3:// href.
     """
-    authentication_classes = [HeaderAPIKeyAuthentication]
+    authentication_classes = _KEY_OR_TOKEN_AUTH
     permission_classes = [HasAPIKey]
 
     @extend_schema(
@@ -109,7 +115,7 @@ class DirectUpFileUploadView(APIView):
     Returns a task ID that can be used to check upload status.
     """
     parser_classes = (MultiPartParser, FormParser)
-    authentication_classes = [HeaderAPIKeyAuthentication]
+    authentication_classes = _KEY_OR_TOKEN_AUTH
     permission_classes = [HasAPIKey]
 
     @extend_schema(
@@ -251,7 +257,7 @@ class UploadStatusView(APIView):
     """
     Check the status of an async upload task.
     """
-    authentication_classes = [HeaderAPIKeyAuthentication]
+    authentication_classes = _KEY_OR_TOKEN_AUTH
     permission_classes = [HasAPIKey]
 
     @extend_schema(


### PR DESCRIPTION
…e endpoints

Adds rest_framework.authentication.TokenAuthentication as an accepted auth method next to the existing X-API-Key header, so admin-generated tokens work too. Extends the same dual auth to the delete endpoints, which previously had no working non-interactive auth path at all.