### PR TITLE
fix: serve ACME HTTP-01 challenge on port 80 in SSL nginx config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,15 @@ connectdb:
 	PGPASSWORD=${POSTGRES_PASSWORD} psql -h localhost -U ${POSTGRES_USER} -d ${POSTGRES_DB}
 connectdb-container:
 	 docker exec -e PGPASSWORD=$(POSTGRES_PASSWORD) -it geodatamanager_db psql -U ${POSTGRES_USER} -d ${POSTGRES_DB} -h ${POSTGRES_HOST} 
+# --- TLS / Let's Encrypt ---------------------------------------------------
+# Bootstrap flow for first-time issuance:
+#   make nginx-bootstrap   # HTTP-only vhost that serves ACME challenges
+#   make certificate       # run certbot webroot HTTP-01 for all domains
+#   make nginx-ssl         # switch to the HTTPS vhost + redirect
+nginx-bootstrap:
+	NGINX_CONFIG=default_pre_ssl.conf docker compose up -d --force-recreate nginx
+nginx-ssl:
+	NGINX_CONFIG=default_ssl.conf docker compose up -d --force-recreate nginx
 certificate:
 	docker compose run --rm certbot
 test:

--- a/env.sample
+++ b/env.sample
@@ -51,11 +51,23 @@ REDIS_PASSWORD=changeme
 REDIS_URL=redis://:changeme@redis:6379/0
 TIPG_DEBUG=True
 
+# nginx vhost config (mounted at /etc/nginx/nginx.conf):
+#   default.conf          - local/dev, HTTP only, server_name-agnostic
+#   default_pre_ssl.conf  - SSL bootstrap: HTTP only, serves ACME challenges
+#   default_ssl.conf      - production: HTTPS + HTTP->HTTPS redirect + ACME
+# First-time cert issuance:
+#   1) set NGINX_CONFIG=default_pre_ssl.conf ; docker compose up -d --force-recreate nginx
+#   2) make certificate
+#   3) set NGINX_CONFIG=default_ssl.conf ; docker compose up -d --force-recreate nginx
 NGINX_CONFIG=default.conf
 
+# Domains for the Let's Encrypt SAN certificate (must all resolve to this host
+# and be reachable on port 80). Consumed by the certbot / certbot-renew services.
 DOMAIN_MINIO_CONSOLE=console-minio.acmad.org
 DOMAIN_MINIO=minio.acmad.org
 DOMAIN=e-safari.acmad.org
+DOMAIN_MULTI_HAZARD=multi-hazard.acmad.org
+EMAIL=admin@acmad.org
 
 TIPG_CORS_ORIGINS=*
 # Google reCAPTCHA v2

--- a/nginx/default_ssl.conf
+++ b/nginx/default_ssl.conf
@@ -11,6 +11,24 @@ http {
      include /etc/nginx/mime.types;
      default_type  application/octet-stream;
 
+    # Plain HTTP: serve ACME challenges (needed for certbot auto-renewal via
+    # webroot HTTP-01, which always probes port 80) and redirect everything
+    # else to HTTPS. Without this block nginx has no :80 listener at all, so
+    # http:// visitors get connection-refused and renewals silently fail.
+    server {
+        listen 80 default_server;
+        server_name e-safari.acmad.org multi-hazard.acmad.org minio.acmad.org console-minio.acmad.org;
+
+        location ^~ /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+            default_type "text/plain";
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
     server {
         listen 443 ssl;
         server_name e-safari.acmad.org;


### PR DESCRIPTION
## Problem

Certbot issuance/renewal fails with `Connection refused` on port 80 for all domains:

```
Detail: 136.244.119.182: Fetching http://minio.acmad.org/.well-known/acme-challenge/... : Connection refused
```

`nginx/default_ssl.conf` contains **only `listen 443 ssl` server blocks** — there is no port-80 listener. Let's Encrypt's HTTP-01 challenge is always fetched over plain HTTP on port 80, so with nothing bound there the CA gets a connection refusal. The `.well-known/acme-challenge/` locations nested inside the 443 blocks are unreachable during issuance, and `certbot-renew` (webroot HTTP-01) would fail the same way in ~60 days.

## Fix

- **`nginx/default_ssl.conf`**: add a `listen 80` server block that serves `/.well-known/acme-challenge/` from `/var/www/certbot` and 301-redirects everything else to HTTPS.
- **`env.sample`**: document the three vhost configs and the first-time issuance order; add the `EMAIL` and `DOMAIN_MULTI_HAZARD` vars the certbot service consumes but that were missing from the sample.
- **`Makefile`**: add `nginx-bootstrap` (mount `default_pre_ssl.conf`) and `nginx-ssl` (mount `default_ssl.conf`) targets.

## Deploy

```bash
make nginx-bootstrap          # HTTP-only vhost, answers ACME challenges
# verify: curl http://e-safari.acmad.org/.well-known/acme-challenge/test
make certificate              # certbot webroot HTTP-01 for all 4 domains
make nginx-ssl                # switch to HTTPS + redirect
```

`nginx -t` passes (only unrelated upstream-DNS errors outside the compose network).