### PR TITLE
fix: make TLS renewal take effect and harden CI deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,13 +195,13 @@ jobs:
     - name: Deploy to Vultr
       run: |
         ssh -o StrictHostKeyChecking=no -p 2224 ${{ secrets.VULTR_USER }}@${{ secrets.VULTR_IP }} << 'EOF'
+          set -euo pipefail
           cd data-infrastructure
-          git pull origin production
-          
-          
+          # Hard-sync instead of `git pull` so a dirty working tree or a
+          # non-fast-forward doesn't silently leave stale code deployed.
+          git fetch origin production
+          git reset --hard origin/production
           docker compose up -d --build
           docker compose --profile prod up -d
           docker builder prune -af
-         
-          
         EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,9 @@ services:
     networks:
       - data_infra_network
     restart: on-failure
+    # Reload every 12h so certbot-renew's freshly issued certs are actually
+    # picked up without a manual `nginx -s reload` or a redeploy.
+    command: sh -c "while :; do sleep 12h & wait $${!}; nginx -s reload; done & nginx -g 'daemon off;'"
   certbot:
     image: certbot/certbot
     container_name: geodatamanager_certbot


### PR DESCRIPTION
Follow-up to #115 (that PR merged before these two changes landed on the branch).

## Changes

- **`docker-compose.yml`** — nginx reloads itself every 12h so the certs `certbot-renew` reissues are actually picked up. Currently nginx holds the cert it loaded at boot until a manual `nginx -s reload` or a full redeploy, so a successful renewal still leaves the old cert being served — which is how both certs reached expiry despite `certbot-renew` running.
- **`.github/workflows/ci.yml`** — the deploy heredoc now runs `set -euo pipefail` and `git fetch` + `git reset --hard origin/production` instead of a bare `git pull`. Previously a failed pull (dirty tree, non-fast-forward, or GitHub throttling the server's unauthenticated git) was ignored and `docker compose up -d --build` ran anyway, so the job went green while shipping stale code.

## Not included (needs a human)

- Register the server's existing `~/.ssh/id_ed25519.pub` (`github-deploy-key`) as a **read-only deploy key** and switch its remote to `git@github.com:...` — removes the anonymous-rate-limit failures on `git pull`.
- `certbot delete --cert-name e-safari.acmad.org-0001` — stray expired duplicate, not referenced by nginx.