### PR TITLE
docs: fix get_tile_params_for_dataset docstring after multi-layer change

### DIFF
--- a/catalog/utils.py
+++ b/catalog/utils.py
@@ -117,7 +117,9 @@ class DatasetVisualization:
 
     def get_tile_params_for_dataset(self):
         """
-        Return tile params for layers tied to this dataset_id (first matching layer).
+        Return tile params for this dataset_id, taken from its primary Layer
+        style (the ``default_visible`` one, else the first by title - matching
+        ``DatasetPage.primary_layer``).
 
         Returns:
             dict or None: Tile params JSON for visualization.


### PR DESCRIPTION
Addresses the single [Copilot review comment on #121](https://github.com/ACMAD-Niamey/data-infrastructure/pull/121#discussion_r-catalog-utils).

`catalog/utils.py` `get_tile_params_for_dataset` was left with a stale docstring ("first matching layer") after #120 switched it to `DatasetPage.primary_layer` (the `default_visible` style, else first by title). Docstring only — no behaviour change.

Rest of that Copilot review was a "needs human review" note on the cross-cutting nature of #120, no other actionable findings.